### PR TITLE
Adds missing author, license, and copyright_holder to dist.ini.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,4 +1,7 @@
+author = Thomas Klausner <domm@plix.at>
 name    = Web-Request-Role-JWT
 copyright_year   = 2017 - 2021
+license = Perl_5
+copyright_holder = Thomas Klausner
 
 [@Author::DOMM]


### PR DESCRIPTION
If `author`, `license`, or `copyright_holder` is missing from `dist.ini`, `dzil build` falls back to the information given in the user's `~/.dzil/config.ini` file. So if the user is not the author of the module, it will cause e.g. `README.md` to be populated with the wrong author information. On the other hand, if the user does not have a `~/.dzil/config.ini` file, `dzil build` will fail due to missing author and license information.

[Assigned by [pullrequest.club](https://pullrequest.club)]